### PR TITLE
fix: imagePullSecrets rendering

### DIFF
--- a/charts/aws-web-service/templates/deployment.yaml
+++ b/charts/aws-web-service/templates/deployment.yaml
@@ -110,9 +110,6 @@ spec:
         ports:
         - containerPort: {{ .Values.deployment.containerPort }}
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
-        {{- with .Values.deployment.imagePullSecrets }}
-        imagePullSecrets: {{ . | toYaml | nindent 8 }}
-        {{- end }}
         envFrom:
         {{- if and .Values.parameterStore.enabled (eq .Values.parameterStore.mountAsFile false) }}
           - secretRef:
@@ -130,6 +127,9 @@ spec:
           - configMapRef:
               name: {{ $.Release.Name }}-{{ $.Chart.Name }}-command
         {{ end }}
+      {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets: {{ . | toYaml | nindent 6 }}
+      {{- end }}
       {{- if .Values.parameterStore.enabled }}
       serviceAccount: {{ .Values.parameterStore.secrets_scm_sa }}
       serviceAccountName: {{ .Values.parameterStore.secrets_scm_sa }}


### PR DESCRIPTION
Following the example in k8s official repository: 
https://github.com/kubernetes/kubernetes/blob/41da26dbe15207cbe5b6c36b48a31d2cd3344123/staging/src/k8s.io/api/testdata/v1.26.0/apps.v1.Deployment.yaml#L609