### PR TITLE
fix: provider template

### DIFF
--- a/charts/az-firestartr-controller/templates/provider.yaml
+++ b/charts/az-firestartr-controller/templates/provider.yaml
@@ -7,11 +7,16 @@ kind: FirestartrProviderConfig
 metadata:
   name: {{ $provider.name }}
 spec:
-  config: '{}'
+  config: | 
+  {{- with $provider.config }}
+    {{- . | nindent 4 -}}
+  {{ else }}
+    {}
+  {{ end }}
   {{ with $provider.inline }}
   inline: | 
     {{ . | nindent 4}}
-  {{ end }}
+  {{- end -}}
   source: {{ $provider.source }}
   type:  {{ $provider.type }}
   version: {{ $provider.version | quote }}


### PR DESCRIPTION
The render provider.yaml was not working properly, with the new fix:

![image](https://github.com/prefapp/charts/assets/91343444/dd9c1ead-2a30-478d-8367-7e0be6c45771)
